### PR TITLE
Changed #minecraft:carpets to #minecraft:wool_carpets

### DIFF
--- a/data/nullscape/worldgen/configured_feature/float/asteroid.json
+++ b/data/nullscape/worldgen/configured_feature/float/asteroid.json
@@ -59,7 +59,7 @@
           "Name": "minecraft:end_stone"
         }
       ],
-      "cannot_replace": "#minecraft:carpets",
+      "cannot_replace": "#minecraft:wool_carpets",
       "invalid_blocks": "#nullscape:end_bottom"
     },
     "layers": {

--- a/data/nullscape/worldgen/configured_feature/float/asteroid_special.json
+++ b/data/nullscape/worldgen/configured_feature/float/asteroid_special.json
@@ -274,7 +274,7 @@
           "Name": "minecraft:obsidian"
         }
       ],
-      "cannot_replace": "#minecraft:carpets",
+      "cannot_replace": "#minecraft:wool_carpets",
       "invalid_blocks": "#nullscape:end_bottom"
     },
     "layers": {


### PR DESCRIPTION
Changed #minecraft:carpets to #minecraft:wool_carpets in...
- data/nullscape/worldgen/configured_feature/float/asteroid.json
- data/nullscape/worldgen/configured_feature/float/asteroid_special.json

Note this should probably go in a seperate 26.2 branch.